### PR TITLE
Prefer WiFi + Apple geocoding

### DIFF
--- a/whereintheworld.xcodeproj/project.pbxproj
+++ b/whereintheworld.xcodeproj/project.pbxproj
@@ -9,6 +9,7 @@
 /* Begin PBXBuildFile section */
 		9E2EC00528DA58B700F5CCD5 /* whereintheworldApp.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E2EC00428DA58B700F5CCD5 /* whereintheworldApp.swift */; };
 		9E2EC00728DA58B700F5CCD5 /* SettingsView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E2EC00628DA58B700F5CCD5 /* SettingsView.swift */; };
+		58BAD6A040A84174B79057A9 /* InfoView.swift in Sources */ = {isa = PBXBuildFile; fileRef = 13BB3EA90E9F420A8DDAA9E2 /* InfoView.swift */; };
 		9E2EC00928DA58B800F5CCD5 /* Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 9E2EC00828DA58B800F5CCD5 /* Assets.xcassets */; };
 		9E2EC00C28DA58B800F5CCD5 /* Preview Assets.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 9E2EC00B28DA58B800F5CCD5 /* Preview Assets.xcassets */; };
 		9E2ECB3F2922CCA200DF408D /* Slack.swift in Sources */ = {isa = PBXBuildFile; fileRef = 9E2ECB3E2922CCA200DF408D /* Slack.swift */; };
@@ -32,6 +33,7 @@
 		9E2EC00128DA58B700F5CCD5 /* whereintheworld.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = whereintheworld.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		9E2EC00428DA58B700F5CCD5 /* whereintheworldApp.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = whereintheworldApp.swift; sourceTree = "<group>"; };
 		9E2EC00628DA58B700F5CCD5 /* SettingsView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = SettingsView.swift; sourceTree = "<group>"; };
+		13BB3EA90E9F420A8DDAA9E2 /* InfoView.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = InfoView.swift; sourceTree = "<group>"; };
 		9E2EC00828DA58B800F5CCD5 /* Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = Assets.xcassets; sourceTree = "<group>"; };
 		9E2EC00B28DA58B800F5CCD5 /* Preview Assets.xcassets */ = {isa = PBXFileReference; lastKnownFileType = folder.assetcatalog; path = "Preview Assets.xcassets"; sourceTree = "<group>"; };
 		9E2EC00D28DA58B800F5CCD5 /* whereintheworld.entitlements */ = {isa = PBXFileReference; lastKnownFileType = text.plist.entitlements; path = whereintheworld.entitlements; sourceTree = "<group>"; };
@@ -141,6 +143,7 @@
 			isa = PBXGroup;
 			children = (
 				9E2EC00628DA58B700F5CCD5 /* SettingsView.swift */,
+				13BB3EA90E9F420A8DDAA9E2 /* InfoView.swift */,
 				9E2ECB582924EFC400DF408D /* SecretsView.swift */,
 				9E2ECB5A2924F3B500DF408D /* SlackStatusSettingsView.swift */,
 				9E2ECB652929973900DF408D /* KnownLocationsSettingsView.swift */,
@@ -223,6 +226,7 @@
 				9E2ECB592924EFC400DF408D /* SecretsView.swift in Sources */,
 				9E2ECB662929973900DF408D /* KnownLocationsSettingsView.swift in Sources */,
 				9E2EC00728DA58B700F5CCD5 /* SettingsView.swift in Sources */,
+				58BAD6A040A84174B79057A9 /* InfoView.swift in Sources */,
 				9E2ECB622929786200DF408D /* SlackStatusDetailView.swift in Sources */,
 				9E2ECB412922CCBE00DF408D /* GoogleMaps.swift in Sources */,
 				9E2ECB432922CCFD00DF408D /* StatusItemController.swift in Sources */,

--- a/whereintheworld/Models/KnownLocation.swift
+++ b/whereintheworld/Models/KnownLocation.swift
@@ -19,7 +19,7 @@ struct KnownLocation: Codable, Identifiable {
             return postcodePrefix ?? ""
         }
         set {
-            postcodePrefix = newValue
+            postcodePrefix = newValue.isEmpty ? nil : newValue
         }
     }
     
@@ -28,7 +28,7 @@ struct KnownLocation: Codable, Identifiable {
             return ssid ?? ""
         }
         set {
-            ssid = newValue
+            ssid = newValue.isEmpty ? nil : newValue
         }
     }
 }

--- a/whereintheworld/Settings/InfoView.swift
+++ b/whereintheworld/Settings/InfoView.swift
@@ -1,0 +1,34 @@
+//
+//  InfoView.swift
+//  whereintheworld
+//
+//  Created by Sebastian Rosch on 18/12/2025.
+//
+
+import SwiftUI
+
+struct InfoView: View {
+    var body: some View {
+        VStack(alignment: .leading, spacing: 12) {
+            Text("About")
+                .font(.headline)
+
+            Text("whereintheworld updates your menu bar with your current location and can optionally set your Slack status.")
+                .fixedSize(horizontal: false, vertical: true)
+
+            Text("Location priority: Wi‑Fi SSID → known postcode prefix → reverse geocoding.")
+                .foregroundColor(.secondary)
+                .fixedSize(horizontal: false, vertical: true)
+        }
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .padding()
+    }
+}
+
+struct InfoView_Previews: PreviewProvider {
+    static var previews: some View {
+        InfoView()
+            .frame(width: 480, height: 240)
+    }
+}
+

--- a/whereintheworld/Settings/KnownLocationDetailView.swift
+++ b/whereintheworld/Settings/KnownLocationDetailView.swift
@@ -30,42 +30,31 @@ struct KnownLocationDetailView: View {
         TypeOption(label:"Other", tag:"other")]
 
     var body: some View {
-        VStack {
-            Form {
-                Section(header: Text("KNOWN LOCATION")) {
-                    TextField("Name", text: $knownLocation.name)
-                    Picker("Type", selection: $knownLocation.type) {
-                        ForEach(typeOptions, id: \.self){ option in
-                            Text(option.label).tag(option.tag)
-                        }
-                    }
-                    TabView {
-                        TextField("Postcode Prefix", text: $knownLocation.postcodePrefixForUI)
-                            .tabItem {
-                                Label("Geolocation", systemImage: "lock.rectangle")
-                                Text("Geolocation")
-                            }
-                        TextField("SSID", text: $knownLocation.ssidForUI)
-                            .tabItem {
-                                Label("WiFi", systemImage: "lock.rectangle")
-                                Text("WiFi")
-                            }
+        Form {
+            Section(header: Text("KNOWN LOCATION")) {
+                TextField("Name", text: $knownLocation.name)
+                Picker("Type", selection: $knownLocation.type) {
+                    ForEach(typeOptions, id: \.self){ option in
+                        Text(option.label).tag(option.tag)
                     }
                 }
+                TextField("WiFi SSID (optional)", text: $knownLocation.ssidForUI)
+                TextField("Postcode Prefix (optional)", text: $knownLocation.postcodePrefixForUI)
             }
-            
-            Button("Delete") {
-                deleteKnownLocation()
+
+            Section {
+                Button("Delete") {
+                    deleteKnownLocation()
+                }
+
+                Button("Save") {
+                    saveKnownLocation()
+                }
+                .buttonStyle(.borderedProminent)
+                .tint(.accentColor)
             }
-            
-            Button("Save") {
-                saveKnownLocation()
-            }
-            .buttonStyle(.borderedProminent)
-            .tint(.accentColor)
         }
-        .onAppear(perform: saveKnownLocation)
-        .padding()
+        .frame(maxWidth: .infinity, maxHeight: .infinity)
     }
     
     func deleteKnownLocation(){
@@ -73,11 +62,6 @@ struct KnownLocationDetailView: View {
     }
     
     func saveKnownLocation(){
-        if (!(knownLocation.postcodePrefix ?? "").isEmpty && !(knownLocation.ssid ?? "").isEmpty) {
-            // If both are set, postcode has priority.
-            knownLocation.ssid = ""
-        }
-        
         delegate?.saveKnownLocation(knownLocation: knownLocation)
     }
 }

--- a/whereintheworld/Settings/KnownLocationsSettingsView.swift
+++ b/whereintheworld/Settings/KnownLocationsSettingsView.swift
@@ -83,6 +83,8 @@ struct KnownLocationsSettingsView: View, KnownLocationDetailDelegate {
         
         knownLocations.append(
             KnownLocation(id: maxId+1, name: "Hamburg Office", type: "office", postcodePrefix: "20459"))
+
+        saveSettings()
         
         // Todo: navigate to new entry
     }
@@ -99,7 +101,8 @@ struct KnownLocationsSettingsView: View, KnownLocationDetailDelegate {
             knownLocations[elementAtIndex] = knownLocation
             saveSettings()
         } else {
-            print("couldn't find element with id \(knownLocation.id)")
+            knownLocations.append(knownLocation)
+            saveSettings()
         }
     }
     

--- a/whereintheworld/Settings/SecretsView.swift
+++ b/whereintheworld/Settings/SecretsView.swift
@@ -10,7 +10,6 @@ import SwiftUI
 
 struct SecretsView: View {
     private var delegate:SettingsViewDelegate?
-    @State private var googleApiKey: String = ""
     @State private var slackApiKey: String = ""
     
     init(delegate:SettingsViewDelegate?) {
@@ -20,7 +19,6 @@ struct SecretsView: View {
     var body: some View {
         VStack {
             Form {
-                SecureInputView("Google Maps API Key", text: $googleApiKey)
                 SecureInputView("Slack API Key", text: $slackApiKey)
             }
             HStack {
@@ -43,12 +41,6 @@ struct SecretsView: View {
         
         let defaults = UserDefaults.standard
         
-        if let googleApiKeyVal = defaults.string(forKey: DefaultsKeys.googleApiKey) {
-            googleApiKey = googleApiKeyVal
-        } else {
-            googleApiKey = ""
-        }
-        
         if let slackApiKeyVal = defaults.string(forKey: DefaultsKeys.slackApiKey) {
             slackApiKey = slackApiKeyVal
         } else {
@@ -60,8 +52,6 @@ struct SecretsView: View {
         print("saving settings")
         
         let defaults = UserDefaults.standard
-        
-        defaults.set(googleApiKey, forKey: DefaultsKeys.googleApiKey)
         defaults.set(slackApiKey, forKey: DefaultsKeys.slackApiKey)
         
         self.delegate?.settingsChanged()
@@ -70,7 +60,6 @@ struct SecretsView: View {
     func clearSettings() {
         print("clearing settings")
         
-        googleApiKey = ""
         slackApiKey = ""
         
         saveSettings()
@@ -106,4 +95,3 @@ struct SecureInputView: View {
         }
     }
 }
-

--- a/whereintheworld/Settings/SettingsView.swift
+++ b/whereintheworld/Settings/SettingsView.swift
@@ -13,7 +13,6 @@ protocol SettingsViewDelegate {
 
 struct SettingsView: View {
     private var delegate:SettingsViewDelegate?
-    @State private var googleApiKey: String = ""
     @State private var slackApiKey: String = ""
     
     init(delegate:SettingsViewDelegate?) {
@@ -28,10 +27,10 @@ struct SettingsView: View {
             Text("where in the world")
             Text("")
             TabView {
-                SecretsView(delegate: self.delegate)
+                InfoView()
                     .tabItem {
-                        Label("Credentials", systemImage: "lock.rectangle")
-                        Text("Credentials")
+                        Label("Info", systemImage: "info.circle")
+                        Text("Info")
                     }
                 SlackStatusSettingsView(delegate: self.delegate)
                     .tabItem {
@@ -42,6 +41,11 @@ struct SettingsView: View {
                     .tabItem {
                         Label("Known Locations", systemImage: "lock.circle")
                         Text("Known Locations")
+                    }
+                SecretsView(delegate: self.delegate)
+                    .tabItem {
+                        Label("Settings", systemImage: "gearshape")
+                        Text("Settings")
                     }
             }
         }


### PR DESCRIPTION
Stops geolocation when a known Wi‑Fi SSID matches. Replaces Google Maps reverse geocoding with CLGeocoder, removing the Google API key requirement. Updates Settings UI (adds Info tab, moves credentials to Settings, improves known location editing) and tightens settings window sizing.